### PR TITLE
projects 配下に Makefile があっても make test が叩かれない不具合の修正

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,7 @@ ADOCS = \
   index.adoc \
   $(wildcard */*.adoc)
 EXAMPLES = $(wildcard */examples/**/*.cr)
-PROJECTS = $(wildcard */projects/*)
+PROJECTS = $(abspath $(wildcard */projects/*))
 PROJECT_CRS = $(and $(PROJECTS), $(shell find $(PROJECTS) -name '*.cr'))
 ASSETS = $(shell find [0-9][0-9]-* -not -name '*.adoc')
 CRS = $(EXAMPLES) $(PROJECT_CRS)


### PR DESCRIPTION
`project-test.rb` での「Makefileがあるかどうかの判定」がうまくいってなかったようなので修正しました。

Makefile 内の `PROJECTS` を絶対パスにしたら通りました。