### PR TITLE
Fix/redpen conf

### DIFF
--- a/config/redpen/conf.xml
+++ b/config/redpen/conf.xml
@@ -27,6 +27,7 @@
     <validator name="InvalidSymbol">
       <symbols>
         <symbol name="NUMBER_SIGN" value="#" invalid-chars="＃" />
+        <symbol name="COMMA" value="、" invalid-chars="，" />
       </symbols>
     </validator>
     <validator name="KatakanaEndHyphen"/>

--- a/config/redpen/conf.xml
+++ b/config/redpen/conf.xml
@@ -47,7 +47,7 @@
     <validator name="GappedSection" />
     <validator name="SectionLevel" />
     <validator name="ParagraphNumber">
-      <property name="max_num" value="10" />
+      <property name="max_num" value="30" />
     </validator>
     <validator name="ListLevel" />
 

--- a/config/redpen/suggestion.txt
+++ b/config/redpen/suggestion.txt
@@ -179,7 +179,6 @@ Internet Explorer6	Internet Explorer 6
 Internet Explorer7	Internet Explorer 7
 Internet Explorer8	Internet Explorer 8
 Internet Explorer9	Internet Explorer 9
-IO	I/O
 ISO1	ISO 1
 ISO2	ISO 2
 ISO3	ISO 4


### PR DESCRIPTION
下記の設定を変更しました。

* 「 `IO` は `I/O` です」というエラーを無くしました
  * `IO` クラスの記述をしたかったため
* `[1, 2]` のように本文へコードを埋め込んだ場合、「 `,` ではなく `、` を使いましょう」と出てしまうエラーを無くしました
* 段落数上限が `10` でしたが、`30`に緩和しました
  * 頻繁にコードブロックを使用すると、簡単に10は超えてしまうため