### PR TITLE
KatakanaEndHyphen の RedPen ルールを削除

### DIFF
--- a/config/redpen/conf.xml
+++ b/config/redpen/conf.xml
@@ -30,7 +30,6 @@
         <symbol name="COMMA" value="、" invalid-chars="，" />
       </symbols>
     </validator>
-    <validator name="KatakanaEndHyphen"/>
     <validator name="KatakanaSpellCheck" level="info"/>
     <validator name="SpaceBetweenAlphabeticalWord" />
     <validator name="ParenthesizedSentence">


### PR DESCRIPTION
例えば「ファイバー」 => 「ファイバ」とかしなくちゃいけなくて厳しいものがある