### PR TITLE
「ファイバー」を KatakanaEndHyphen ルールで許容する

### DIFF
--- a/config/redpen/conf.xml
+++ b/config/redpen/conf.xml
@@ -30,7 +30,9 @@
         <symbol name="COMMA" value="、" invalid-chars="，" />
       </symbols>
     </validator>
-    <validator name="KatakanaEndHyphen"/>
+    <validator name="KatakanaEndHyphen">
+        <property name="list" value="ファイバー" />
+    </validator>
     <validator name="KatakanaSpellCheck" level="info"/>
     <validator name="SpaceBetweenAlphabeticalWord" />
     <validator name="ParenthesizedSentence">

--- a/config/redpen/conf.xml
+++ b/config/redpen/conf.xml
@@ -31,7 +31,7 @@
       </symbols>
     </validator>
     <validator name="KatakanaEndHyphen">
-        <property name="list" value="ファイバー" />
+      <property name="list" value="ファイバー" />
     </validator>
     <validator name="KatakanaSpellCheck" level="info"/>
     <validator name="SpaceBetweenAlphabeticalWord" />


### PR DESCRIPTION
KatakanaEndHyphen ルールにより「ファイバー」 => 「ファイバ」にしなくちゃいけなくて厳しいものがあったのでファイバーは許容する。