### PR TITLE
JapaneseJoyoKanji を Warn に格下げ

### DIFF
--- a/config/redpen/conf.xml
+++ b/config/redpen/conf.xml
@@ -16,7 +16,7 @@
     <validator name="Okurigana"/>
     <validator name="JapaneseNumberExpression"/>
     <validator name="JapaneseAmbiguousNounConjunction" />
-    <validator name="JapaneseJoyoKanji" />
+    <validator name="JapaneseJoyoKanji" level="Warn"/>
     <validator name="LongKanjiChain" />
     <validator name="DoubledConjunctiveParticleGa" />
     <validator name="SuggestExpression">


### PR DESCRIPTION
常用漢字以外を使用した際にエラーにならないようにします。