### PR TITLE
[WIP] CircleCIのDockerイメージを更新

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2.0
 jobs:
   build:
     docker:
-      - image: makenowjust/techbookfest-build:0.24.2-1
+      - image: makenowjust/techbookfest-build:latest
     steps:
       - checkout
       - restore_cache:


### PR DESCRIPTION
タグなどは打たれていませんでしたがDockerイメージの最新ビルドがあるようだったので反映しました。
https://hub.docker.com/r/makenowjust/techbookfest-build/tags/

実際に自分の担当箇所のコードを0.26準拠に書き直したらエラーになるようになったためです。